### PR TITLE
ci: bump setup-node to v4

### DIFF
--- a/.github/workflows/e2e-playwright-tests.yml
+++ b/.github/workflows/e2e-playwright-tests.yml
@@ -73,7 +73,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 22.12.0
 

--- a/.github/workflows/legends-staging.yml
+++ b/.github/workflows/legends-staging.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Node.js ⚙️
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc
 


### PR DESCRIPTION
Maintenance update: switch all jobs to setup-node@v4 for better performance and compatibility. Pure maintenance, behavior unchanged. More details in the [v4.0.0 release](https://github.com/actions/setup-node/releases/tag/v4.0.0).