### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/benzin.yml
+++ b/.github/workflows/benzin.yml
@@ -23,7 +23,7 @@ jobs:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Checkout code 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Git submodules init
         run: git submodule init

--- a/.github/workflows/build-extension-gecko.yml
+++ b/.github/workflows/build-extension-gecko.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Checkout code 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Add SSH key to checkout a private repo
         uses: webfactory/ssh-agent@v0.5.4

--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -14,7 +14,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
       - name: Checkout code 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Add SSH key to checkout a private repo
         uses: webfactory/ssh-agent@v0.5.4

--- a/.github/workflows/e2e-playwright-tests.yml
+++ b/.github/workflows/e2e-playwright-tests.yml
@@ -64,7 +64,7 @@ jobs:
 
     steps:
       - name: Checkout full Git history
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # Fixes GitCommitInfo timeout
 

--- a/.github/workflows/legends-staging.yml
+++ b/.github/workflows/legends-staging.yml
@@ -22,7 +22,7 @@ jobs:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Checkout code 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Node.js ⚙️
         uses: actions/setup-node@v4

--- a/.github/workflows/legends.yml
+++ b/.github/workflows/legends.yml
@@ -22,7 +22,7 @@ jobs:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Checkout code 🛎️
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Git submodules init
         run: git submodule init

--- a/.github/workflows/public-update.yml
+++ b/.github/workflows/public-update.yml
@@ -21,7 +21,7 @@ jobs:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Checkout code 🛎️
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: main


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0