### PR TITLE
feat: add Tenderly simulation support for Safe accounts in error details

### DIFF
--- a/src/common/modules/sign-account-op/components/ErrorInformation/ErrorInformation.tsx
+++ b/src/common/modules/sign-account-op/components/ErrorInformation/ErrorInformation.tsx
@@ -5,9 +5,11 @@ import { View } from 'react-native'
 
 import AmbireAccount from '@ambire-common/../contracts/compiled/AmbireAccount.json'
 import AmbireFactory from '@ambire-common/../contracts/compiled/AmbireFactory.json'
+import { execTransactionAbi } from '@ambire-common/consts/safe'
 import { DEPLOYLESS_SIMULATION_FROM } from '@ambire-common/consts/deploy'
 import { getSpoof } from '@ambire-common/libs/account/account'
 import { getSignableCalls } from '@ambire-common/libs/accountOp/accountOp'
+import { getSafeTxn } from '@ambire-common/libs/safe/safe'
 import { getErrorCodeStringFromReason } from '@ambire-common/libs/errorDecoder/helpers'
 import CopyIcon from '@common/assets/svg/CopyIcon'
 import AlertVertical from '@common/components/AlertVertical'
@@ -84,6 +86,50 @@ const ErrorInformation = () => {
             value: '0'
           })
         }
+      } else if (signAccountOpState.account.safeCreation && state.isDeployed) {
+        const firstSigner = state.associatedKeys[0]
+        if (!firstSigner) throw new Error('No Safe owners found')
+
+        const safeTxn = getSafeTxn(signAccountOpState.accountOp, state)
+        const exec = new Interface(execTransactionAbi)
+        const preValidatedSig = `0x000000000000000000000000${firstSigner.slice(2).toLowerCase()}000000000000000000000000000000000000000000000000000000000000000001`
+        const execData = exec.encodeFunctionData('execTransaction', [
+          safeTxn.to,
+          safeTxn.value,
+          safeTxn.data,
+          safeTxn.operation,
+          safeTxn.safeTxGas,
+          safeTxn.baseGas,
+          safeTxn.gasPrice,
+          safeTxn.gasToken,
+          safeTxn.refundReceiver,
+          preValidatedSig
+        ])
+
+        const urlParams: Record<string, string> = {
+          network: signAccountOpState.accountOp.chainId.toString(),
+          from: firstSigner,
+          contractAddress: signAccountOpState.accountOp.accountAddr,
+          rawFunctionInput: execData,
+          value: '0'
+        }
+
+        if (state.threshold > 1) {
+          const stateOverrides = JSON.stringify([
+            {
+              contractAddress: signAccountOpState.accountOp.accountAddr,
+              storage: [
+                {
+                  key: '0x0000000000000000000000000000000000000000000000000000000000000004',
+                  value: '0x0000000000000000000000000000000000000000000000000000000000000001'
+                }
+              ]
+            }
+          ])
+          urlParams.stateOverrides = stateOverrides
+        }
+
+        params = new URLSearchParams(urlParams)
       } else {
         // only a single call for EOAs
         const call = signAccountOpState.accountOp.calls[0]!

--- a/src/common/modules/sign-account-op/components/ErrorInformation/ErrorInformation.tsx
+++ b/src/common/modules/sign-account-op/components/ErrorInformation/ErrorInformation.tsx
@@ -2,6 +2,7 @@ import { Interface } from 'ethers'
 import { setStringAsync } from 'expo-clipboard'
 import React, { useCallback, useMemo } from 'react'
 import { View } from 'react-native'
+import { v4 as uuidv4 } from 'uuid'
 
 import AmbireAccount from '@ambire-common/../contracts/compiled/AmbireAccount.json'
 import AmbireFactory from '@ambire-common/../contracts/compiled/AmbireFactory.json'
@@ -106,30 +107,57 @@ const ErrorInformation = () => {
           preValidatedSig
         ])
 
-        const urlParams: Record<string, string> = {
-          network: signAccountOpState.accountOp.chainId.toString(),
-          from: firstSigner,
-          contractAddress: signAccountOpState.accountOp.accountAddr,
-          rawFunctionInput: execData,
-          value: '0'
+        // Tenderly's new UI uses base64 encoded json to provide simulation
+        // parameters. The new format is required to use state overrides
+        const draftTemplate = {
+          v: 1,
+          network: { id: signAccountOpState.accountOp.chainId.toString() },
+          row: {
+            from: firstSigner,
+            gas: '0',
+            gasPrice: '0',
+            value: 0,
+            block: '',
+            blockIndex: null,
+            endOfBlock: false,
+            usePendingBlock: true,
+            depositTx: false,
+            systemTx: false,
+            mint: '0',
+            l1BlockNumber: '',
+            l1Timestamp: '',
+            l1MessageSender: '0x0000000000000000000000000000000000000000',
+            l1Turing: '',
+            contractAddress: signAccountOpState.accountOp.accountAddr,
+            functionInputs: {},
+            inputDataType: 'raw',
+            rawFunctionInput: execData,
+            contractAbiImport: '',
+            blockHeaderOverrides: {},
+            stateOverrides:
+              state.threshold > 1
+                ? [
+                    {
+                      id: uuidv4(),
+                      contractAddress: signAccountOpState.accountOp.accountAddr,
+                      balance: '',
+                      storage: [
+                        {
+                          key: '0x0000000000000000000000000000000000000000000000000000000000000004', // threshold slot
+                          value:
+                            '0x0000000000000000000000000000000000000000000000000000000000000001'
+                        }
+                      ]
+                    }
+                  ]
+                : [],
+            contractFunction: null
+          }
         }
 
-        if (state.threshold > 1) {
-          const stateOverrides = JSON.stringify([
-            {
-              contractAddress: signAccountOpState.accountOp.accountAddr,
-              storage: [
-                {
-                  key: '0x0000000000000000000000000000000000000000000000000000000000000004',
-                  value: '0x0000000000000000000000000000000000000000000000000000000000000001'
-                }
-              ]
-            }
-          ])
-          urlParams.stateOverrides = stateOverrides
-        }
-
-        params = new URLSearchParams(urlParams)
+        params = new URLSearchParams({
+          draft: btoa(JSON.stringify(draftTemplate)).replace(/=+$/, '') // remove trailing padding, tenderly doesn't use it
+        })
       } else {
         // only a single call for EOAs
         const call = signAccountOpState.accountOp.calls[0]!


### PR DESCRIPTION
Add Safe-specific transaction simulation in ErrorInformation when signing with a Safe account. Handles both safe creation and deployed Safes, with state overrides for multi-sig threshold reduction when threshold > 1.