### PR TITLE
add: GNS (.gwei) names support

### DIFF
--- a/src/common/assets/svg/GnsIcon/GnsIcon.tsx
+++ b/src/common/assets/svg/GnsIcon/GnsIcon.tsx
@@ -1,0 +1,24 @@
+import React, { FC } from 'react'
+import Svg, { Path, SvgProps } from 'react-native-svg'
+
+import useTheme from '@common/hooks/useTheme'
+
+const GnsIcon: FC<
+  SvgProps & {
+    isActive?: boolean
+  }
+> = ({ width = 24, height = 24, color, isActive, ...rest }) => {
+  const { theme } = useTheme()
+
+  return (
+    <Svg width={width} height={height} fill="none" {...rest} viewBox="0 0 16 16">
+      <Path
+        opacity={isActive ? '1' : '0.5'}
+        fill={color || theme.iconPrimary}
+        d="M3 3h10v2H3zM3 3h2v11H3zM3 12h10v2H3zM11 9h2v5h-2zM8 9h5v2H8z"
+      />
+    </Svg>
+  )
+}
+
+export default React.memo(GnsIcon)

--- a/src/common/assets/svg/GnsIcon/index.ts
+++ b/src/common/assets/svg/GnsIcon/index.ts
@@ -1,0 +1,3 @@
+import GnsIcon from './GnsIcon'
+
+export default GnsIcon

--- a/src/common/components/AddressInput/AddressInput.tsx
+++ b/src/common/components/AddressInput/AddressInput.tsx
@@ -10,6 +10,7 @@ import shortenAddress from '@ambire-common/utils/shortenAddress'
 import CloseIcon from '@common/assets/svg/CloseIcon'
 import CopyIcon from '@common/assets/svg/CopyIcon'
 import EnsIcon from '@common/assets/svg/EnsIcon'
+import GnsIcon from '@common/assets/svg/GnsIcon'
 import NamoshiIcon from '@common/assets/svg/NamoshiIcon'
 import AddressBookContact from '@common/components/AddressBookContact'
 import Input, { InputProps } from '@common/components/Input'
@@ -110,7 +111,7 @@ const AddressInput: React.FC<Props> = ({
         validLabelAppearance={severity ? `${severity}Text` : undefined}
         error={isError ? message : ''}
         isValid={!isError && !isValidationInDomainResolvingState}
-        placeholder={placeholder || t('Address / ENS / Namoshi')}
+        placeholder={placeholder || t('Address / ENS / Namoshi / GNS')}
         bottomLabelStyle={styles.bottomLabel}
         info={
           !isError && severity === 'info'
@@ -152,6 +153,7 @@ const AddressInput: React.FC<Props> = ({
                   <View style={[flexbox.directionRow, flexbox.alignCenter]}>
                     {resolvedAddressType === 'ens' && <EnsIcon isActive />}
                     {resolvedAddressType === 'namoshi' && <NamoshiIcon isActive />}
+                    {resolvedAddressType === 'gwei' && <GnsIcon isActive />}
                   </View>
                 )}
               </View>

--- a/src/common/components/Avatar/DomainBadge/DomainBadge.tsx
+++ b/src/common/components/Avatar/DomainBadge/DomainBadge.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react'
 import { View } from 'react-native'
 
 import EnsCircularIcon from '@common/assets/svg/EnsCircularIcon'
+import GnsIcon from '@common/assets/svg/GnsIcon'
 import NamoshiIcon from '@common/assets/svg/NamoshiIcon'
 import { ReverseLookupResult } from '@common/hooks/useReverseLookup/useReverseLookup'
 import spacings from '@common/styles/spacings'
@@ -13,6 +14,7 @@ const DomainBadge: FC<Pick<ReverseLookupResult, 'name' | 'type'>> = ({ name, typ
     <View style={{ zIndex: 2, borderRadius: 50, ...spacings.mrMi }}>
       {type === 'ens' && <EnsCircularIcon />}
       {type === 'namoshi' && <NamoshiIcon width={16} height={16} isActive />}
+      {type === 'gwei' && <GnsIcon width={16} height={16} isActive />}
     </View>
   )
 }

--- a/src/common/hooks/useAccountsList/useAccountsList.tsx
+++ b/src/common/hooks/useAccountsList/useAccountsList.tsx
@@ -46,6 +46,7 @@ const useAccountsList = ({
           .join(' '),
         ens: domains[account.addr]?.ens?.toLowerCase().trim() || '',
         namoshi: domains[account.addr]?.namoshi?.toLowerCase().trim() || '',
+        gwei: domains[account.addr]?.gwei?.toLowerCase().trim() || '',
         address: account.addr.toLowerCase(),
         smart: isSmartAccount(account) ? 'smart' : ''
       })),
@@ -60,6 +61,7 @@ const useAccountsList = ({
         { name: 'label', weight: 0.5 },
         { name: 'ens', weight: 0.3 },
         { name: 'namoshi', weight: 0.3 },
+        { name: 'gwei', weight: 0.3 },
         { name: 'address', weight: 0.1 },
         { name: 'keyLabels', weight: 0.2 },
         { name: 'smart', weight: 0.1 }

--- a/src/common/hooks/useAddressInput/useAddressInput.tsx
+++ b/src/common/hooks/useAddressInput/useAddressInput.tsx
@@ -60,6 +60,7 @@ const useAddressInput = ({
         isRecipientDomainResolving: addressState.isDomainResolving,
         isValidEns: addressState.resolvedAddressType === 'ens',
         isValidNamoshi: addressState.resolvedAddressType === 'namoshi',
+        isValidGwei: addressState.resolvedAddressType === 'gwei',
         hasDomainResolveFailed,
         overwriteValidation
       }),

--- a/src/common/hooks/useAddressInput/utils/validation.ts
+++ b/src/common/hooks/useAddressInput/utils/validation.ts
@@ -1,7 +1,7 @@
 import { getAddress } from 'ethers'
 
 import { isValidAddress } from '@ambire-common/services/address'
-import { getIsNamoshiDomain } from '@ambire-common/services/ensDomains'
+import { getIsGweiDomain, getIsNamoshiDomain } from '@ambire-common/services/ensDomains'
 import { Validation } from '@ambire-common/services/validations'
 
 type AddressInputValidation = {
@@ -9,6 +9,7 @@ type AddressInputValidation = {
   isRecipientDomainResolving: boolean
   isValidEns: boolean
   isValidNamoshi: boolean
+  isValidGwei: boolean
   hasDomainResolveFailed: boolean
   overwriteValidation?: Validation | null
 }
@@ -28,6 +29,7 @@ const getAddressInputValidation = ({
   hasDomainResolveFailed = false,
   isValidEns,
   isValidNamoshi,
+  isValidGwei,
   overwriteValidation
 }: AddressInputValidation): Validation => {
   if (!address) {
@@ -48,9 +50,10 @@ const getAddressInputValidation = ({
 
   if (hasDomainResolveFailed) {
     const isNamoshiDomain = getIsNamoshiDomain(address)
+    const isGweiDomain = getIsGweiDomain(address)
 
     return {
-      message: `Failed to resolve ${isNamoshiDomain ? 'Namoshi' : 'ENS'} domain. Please try again later or enter a hex address.`,
+      message: `Failed to resolve ${isNamoshiDomain ? 'Namoshi' : isGweiDomain ? 'GNS' : 'ENS'} domain. Please try again later or enter a hex address.`,
       severity: 'error'
     }
   }
@@ -73,14 +76,14 @@ const getAddressInputValidation = ({
     }
   }
 
-  // ENS/Namoshi that looks like an address
+  // ENS/Namoshi/GNS that looks like an address
   if (
-    (isValidNamoshi || isValidEns) &&
+    (isValidNamoshi || isValidEns || isValidGwei) &&
     address.indexOf('.') !== -1 &&
     isValidAddress(address.split('.')[0] || '')
   ) {
     return {
-      message: `This {${isValidNamoshi ? 'Namoshi' : 'ENS'}} name may not point to the address you expect. Double-check before sending.`,
+      message: `This {${isValidNamoshi ? 'Namoshi' : isValidGwei ? 'GNS' : 'ENS'}} name may not point to the address you expect. Double-check before sending.`,
       severity: 'warning'
     }
   }
@@ -95,9 +98,14 @@ const getAddressInputValidation = ({
       message: 'Valid Namoshi domain',
       severity: 'success'
     }
+  } else if (isValidGwei) {
+    successValidation = {
+      message: 'Valid GNS domain',
+      severity: 'success'
+    }
   } else if (address && !isValidAddress(address)) {
     return {
-      message: 'Please enter a valid address or ENS/Namoshi domain',
+      message: 'Please enter a valid address or ENS/Namoshi/GNS domain',
       severity: 'error'
     }
   }

--- a/src/common/hooks/useResolveDomain/useResolveDomain.tsx
+++ b/src/common/hooks/useResolveDomain/useResolveDomain.tsx
@@ -9,7 +9,9 @@ interface Props {
 
 // Define the type for our pending promises tracker
 type Resolver = {
-  resolve: (result: { address: string | undefined; type: 'ens' | 'namoshi' } | undefined) => void
+  resolve: (
+    result: { address: string | undefined; type: 'ens' | 'namoshi' | 'gwei' } | undefined
+  ) => void
   reject: (reason?: any) => void
 }
 
@@ -42,7 +44,9 @@ const useResolveDomain = () => {
     ({
       domain,
       bip44Item
-    }: Props): Promise<{ address: string | undefined; type: 'ens' | 'namoshi' } | undefined> => {
+    }: Props): Promise<
+      { address: string | undefined; type: 'ens' | 'namoshi' | 'gwei' } | undefined
+    > => {
       const status = resolveDomainsStatus[domain]
 
       if (status === 'RESOLVED') return Promise.resolve(domainToAddresses[domain])

--- a/src/common/hooks/useReverseLookup/useReverseLookup.tsx
+++ b/src/common/hooks/useReverseLookup/useReverseLookup.tsx
@@ -10,7 +10,7 @@ interface Props {
 export interface ReverseLookupResult {
   isLoading: boolean
   name: string | null | undefined
-  type: 'ens' | 'namoshi' | null
+  type: 'ens' | 'namoshi' | 'gwei' | null
 }
 
 const useReverseLookup = ({ address }: Props): ReverseLookupResult => {
@@ -33,8 +33,14 @@ const useReverseLookup = ({ address }: Props): ReverseLookupResult => {
 
   return {
     isLoading: isLoading || !addressInDomains,
-    name: addressInDomains?.ens || addressInDomains?.namoshi,
-    type: addressInDomains?.ens ? 'ens' : addressInDomains?.namoshi ? 'namoshi' : null
+    name: addressInDomains?.ens || addressInDomains?.namoshi || addressInDomains?.gwei,
+    type: addressInDomains?.ens
+      ? 'ens'
+      : addressInDomains?.namoshi
+        ? 'namoshi'
+        : addressInDomains?.gwei
+          ? 'gwei'
+          : null
   }
 }
 

--- a/src/web/modules/settings/screens/AddressBookSettingsScreen/components/AddContactFormModal/AddContactFormModal.tsx
+++ b/src/web/modules/settings/screens/AddressBookSettingsScreen/components/AddContactFormModal/AddContactFormModal.tsx
@@ -168,7 +168,7 @@ const AddContactFormModal = ({ id, sheetRef, closeBottomSheet }: Props) => {
               render={({ field: { onChange, onBlur } }) => (
                 <View style={{ width: '100%' }}>
                   <AddressInput
-                    label={t('Address / ENS / Namoshi')}
+                    label={t('Address / ENS / Namoshi / GNS')}
                     onChangeText={(text) => {
                       onChange(text)
                       trigger('addressState.fieldValue')


### PR DESCRIPTION
## What

UI counterpart of AmbireTech/ambire-common#2522: surfaces **GNS (`.gwei`) names** everywhere ENS and Namoshi names already appear.

- `GnsIcon`: new svg component (the GNS pixel-G), theme-aware, same shape as `NamoshiIcon`.
- `AddressInput`: `.gwei` resolution icon and the "Address / ENS / Namoshi / GNS" placeholder.
- `DomainBadge`: GNS badge next to avatars (account rows, address book, signing screens, Benzin).
- `useAddressInput` / `validation`: `isValidGwei`, "Valid GNS domain", failure and warning messages.
- `useResolveDomain` / `useReverseLookup`: `'gwei'` in the type unions, reverse-name fallback chain.
- `useAccountsList`: `.gwei` names included in the account fuzzy search.
- Address Book add-contact modal label.

## Depends on

**AmbireTech/ambire-common#2522** (adds the `gwei` fields and `resolvedAddressType` union this code reads). This branch deliberately does not touch the submodule pointer; type-checks will go green once the submodule is bumped past that PR. Marked as draft until then.

To try it now: point `src/ambire-common` at `lucadonnoh/ambire-common#feature/gwei-names`, then type a `.gwei` name (e.g. `donnoh.gwei`, live on mainnet with a primary name set, so both directions demo) into Send or Add Contact.

## Verification

- `yarn extension:type:check-new` with the common branch checked out in the submodule: "0 new errors found. 159 errors already in baseline."
- `npx eslint` on all touched files: nothing on changed lines.
- ambire-common side is covered by real-RPC jest tests in the companion PR (24/24).
