### PR TITLE
feat: keep private keys visually hidden after export authentication

### DIFF
--- a/e2e-playwright-tests/pages/accountKeysPage.ts
+++ b/e2e-playwright-tests/pages/accountKeysPage.ts
@@ -95,8 +95,35 @@ export class AccountKeysPage extends BasePage {
 
     const keyEl = this.page.getByTestId(selectors.keystoreMigration.privateKeyValue)
     await expect(keyEl).not.toBeEmpty({ timeout: 15000 })
+    const copyBtn = this.page.getByTestId(selectors.keystoreMigration.copyPrivateKeyButton)
+    await expect(copyBtn).toBeVisible()
+    await expect(revealBtn).toHaveText('Show key')
+    await expect(keyEl.locator('..')).toHaveCSS('filter', 'blur(3px)')
+
+    await this.context.grantPermissions(['clipboard-read', 'clipboard-write'])
+    await this.page.evaluate(() => navigator.clipboard.writeText('clipboard-test-sentinel'))
+    let copiedPrivateKeyMatches = false
+    try {
+      await copyBtn.click()
+      await expect(this.page.getByText('Private key copied to clipboard!')).toBeVisible()
+      copiedPrivateKeyMatches = await keyEl.evaluate(async (element) => {
+        return (await navigator.clipboard.readText()) === element.textContent
+      })
+    } finally {
+      await this.page.evaluate(() => navigator.clipboard.writeText(''))
+    }
+    expect(copiedPrivateKeyMatches).toBe(true)
+
+    await expect(revealBtn).toHaveText('Show key')
+    await expect(keyEl.locator('..')).toHaveCSS('filter', 'blur(3px)')
+
+    await revealBtn.click()
+    await expect(revealBtn).toHaveText('Hide key')
 
     const privateKey = await keyEl.innerText()
+
+    await revealBtn.click()
+    await expect(revealBtn).toHaveText('Reveal key')
 
     // Close ExportKey then AccountKeys — each call drops visible count by 1
     await this.closeTopSheet()

--- a/e2e-playwright-tests/tests/settings/keystore/privateKeyExport.spec.ts
+++ b/e2e-playwright-tests/tests/settings/keystore/privateKeyExport.spec.ts
@@ -1,0 +1,29 @@
+import { PRIVATE_KEY } from 'constants/env'
+import { ethers } from 'ethers'
+
+import { test } from '../../../fixtures/pageObjects'
+
+test.describe('private key export', { tag: '@keystore' }, () => {
+  test.beforeEach(async ({ pages }) => {
+    await pages.initWithoutStorage()
+    await Promise.all(
+      pages.auth.context
+        .pages()
+        .filter((page) => page !== pages.auth.page)
+        .map((page) => page.close())
+    )
+  })
+
+  test.afterEach(async ({ context }) => {
+    await context.close()
+  })
+
+  test('allows copying the private key while it remains hidden after authentication', async ({
+    pages
+  }) => {
+    await pages.auth.importExistingAccount()
+
+    const keyAddress = ethers.computeAddress(PRIVATE_KEY)
+    await pages.accountKeys.exportPrivateKey(keyAddress, keyAddress)
+  })
+})

--- a/src/common/components/ExportKey/ExportKey.tsx
+++ b/src/common/components/ExportKey/ExportKey.tsx
@@ -102,8 +102,6 @@ const ExportKey = ({
       })
     }
 
-    if (blurred) setBlurred(false)
-
     closeConfirmPassword()
   }
 

--- a/src/common/components/ExportKey/PrivateKeyExport/PrivateKeyExport.tsx
+++ b/src/common/components/ExportKey/PrivateKeyExport/PrivateKeyExport.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useCallback } from 'react'
+import React, { FC, useCallback, useMemo } from 'react'
 import { View } from 'react-native'
 
 import CopyIcon from '@common/assets/svg/CopyIcon'
@@ -29,6 +29,12 @@ const PrivateKeyExport: FC<Props> = ({ privateKey, blurred, setBlurred, openConf
 
   const { theme, styles } = useTheme(getStyles)
   const { addToast } = useToast()
+
+  const visibilityButtonText = useMemo(() => {
+    if (!privateKey) return t('Reveal key')
+
+    return blurred ? t('Show key') : t('Hide key')
+  }, [blurred, privateKey, t])
 
   const handleCopyText = useCallback(async () => {
     if (!privateKey) return
@@ -100,7 +106,7 @@ const PrivateKeyExport: FC<Props> = ({ privateKey, blurred, setBlurred, openConf
               hasBottomSpacing={false}
               type={isWeb ? 'ghost' : 'outline'}
               size={isWeb ? 'small' : 'regular'}
-              text={blurred ? t('Reveal key') : t('Hide key')}
+              text={visibilityButtonText}
             >
               {blurred ? (
                 <VisibilityIcon color={theme.iconPrimary} style={spacings.mlTy} width={18} />


### PR DESCRIPTION
Adds an intermediate state to the private key export flow so authentication no longer visually reveals the private key automatically.

After entering their password, users can:

- Copy the private key while it remains blurred.
- Select **Show key** to reveal it.
- Select **Hide key** to relock the export and return to the **Reveal key** state.

I added this because I almost always just want to copy the key, I don't need or want to visually expose it. I personally think it is safer to allow copying the key without forcing it to be visually shown before it can be copied.

## Files changed

- `src/common/components/ExportKey/ExportKey.tsx`: Keeps the private key blurred after successful password authentication instead of revealing it automatically.
- `src/common/components/ExportKey/PrivateKeyExport/PrivateKeyExport.tsx`: Adds the appropriate **Reveal key**, **Show key**, and **Hide key** button labels for each export state.
- `e2e-playwright-tests/pages/accountKeysPage.ts`: Verifies that the authenticated key remains blurred, can be copied while hidden, can be shown, and returns to the authentication state when hidden.
- `e2e-playwright-tests/tests/settings/keystore/privateKeyExport.spec.ts`: Adds a focused `@keystore` E2E scenario covering the updated private key export flow.