### PR TITLE
Add: allow view-only accounts to prepare unsigned transactions

### DIFF
--- a/src/common/modules/sign-account-op/components/CopyUnsignedTransaction/CopyUnsignedTransaction.tsx
+++ b/src/common/modules/sign-account-op/components/CopyUnsignedTransaction/CopyUnsignedTransaction.tsx
@@ -1,0 +1,170 @@
+import React, { FC, memo, useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { View } from 'react-native'
+
+import { ISignAccountOpController } from '@ambire-common/interfaces/signAccountOp'
+import CopyIcon from '@common/assets/svg/CopyIcon'
+import Button from '@common/components/Button'
+import Text from '@common/components/Text'
+import TextArea from '@common/components/TextArea'
+import { GEIST_MONO_FONT_FAMILIES } from '@common/hooks/useFonts'
+import useTheme from '@common/hooks/useTheme'
+import useToast from '@common/hooks/useToast'
+import spacings from '@common/styles/spacings'
+import flexbox from '@common/styles/utils/flexbox'
+import { setStringAsync } from '@common/utils/clipboard'
+
+const GENERATION_TIMEOUT_MS = 15000
+
+interface Props {
+  signAccountOpState: ISignAccountOpController | null
+  onGenerate: () => void
+}
+
+const CopyUnsignedTransaction: FC<Props> = ({ signAccountOpState, onGenerate }) => {
+  const { t } = useTranslation()
+  const { theme } = useTheme()
+  const { addToast } = useToast()
+  const [hasGenerationTimedOut, setHasGenerationTimedOut] = useState(false)
+  const generationRequestedRef = useRef(false)
+  const generationTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const onGenerateRef = useRef(onGenerate)
+
+  const unsignedTransaction = signAccountOpState?.unsignedTransaction ?? null
+  const gasFeePayment = signAccountOpState?.accountOp?.gasFeePayment ?? null
+
+  const isViewOnlyEOA =
+    !!signAccountOpState &&
+    !signAccountOpState.account.safeCreation &&
+    !signAccountOpState.account.creation &&
+    (signAccountOpState.accountKeyStoreKeys?.length || 0) === 0
+
+  useEffect(() => {
+    onGenerateRef.current = onGenerate
+  })
+
+  useEffect(() => {
+    return () => {
+      if (generationTimeoutRef.current) clearTimeout(generationTimeoutRef.current)
+    }
+  }, [])
+
+  // Generate the unsigned transaction automatically once the fee estimation for
+  // the view-only EOA account completes (the raw tx cannot be built without it).
+  const canGenerate = isViewOnlyEOA && !!gasFeePayment
+  useEffect(() => {
+    if (!canGenerate || generationRequestedRef.current || !!unsignedTransaction) return
+
+    generationRequestedRef.current = true
+    onGenerateRef.current()
+
+    if (generationTimeoutRef.current) clearTimeout(generationTimeoutRef.current)
+    generationTimeoutRef.current = setTimeout(
+      () => setHasGenerationTimedOut(true),
+      GENERATION_TIMEOUT_MS
+    )
+  }, [canGenerate, unsignedTransaction])
+
+  const handleRetry = useCallback(() => {
+    generationRequestedRef.current = false
+    setHasGenerationTimedOut(false)
+    onGenerateRef.current()
+
+    if (generationTimeoutRef.current) clearTimeout(generationTimeoutRef.current)
+    generationTimeoutRef.current = setTimeout(
+      () => setHasGenerationTimedOut(true),
+      GENERATION_TIMEOUT_MS
+    )
+  }, [])
+
+  const handleCopy = useCallback(async () => {
+    if (!unsignedTransaction) return
+
+    try {
+      await setStringAsync(unsignedTransaction)
+      addToast(t('Copied to clipboard!') as string, { timeout: 2500 })
+    } catch {
+      addToast(t('Failed to copy') as string)
+    }
+  }, [addToast, t, unsignedTransaction])
+
+  if (!isViewOnlyEOA) return null
+
+  const isWaitingForEstimation = !gasFeePayment
+  const isGenerating = !!gasFeePayment && !unsignedTransaction && !hasGenerationTimedOut
+
+  return (
+    <View
+      style={[
+        spacings.mt,
+        spacings.ph,
+        spacings.pv,
+        {
+          borderWidth: 1,
+          borderColor: theme.secondaryBorder,
+          borderRadius: 12,
+          backgroundColor: theme.secondaryBackground
+        }
+      ]}
+    >
+      <Text appearance="primaryText" fontSize={14} weight="semiBold" style={spacings.mbSm}>
+        {t('Unsigned transaction')}
+      </Text>
+      <Text appearance="secondaryText" fontSize={12} style={spacings.mb}>
+        {t(
+          'This account is view-only, so it cannot sign here. You can still prepare the unsigned transaction and sign it with any wallet that holds the private key for this address.'
+        )}
+      </Text>
+      <View style={[flexbox.directionRow, flexbox.alignCenter]}>
+        <View style={[flexbox.flex1, spacings.mrSm]}>
+          <TextArea
+            value={unsignedTransaction ?? ''}
+            placeholder={
+              isWaitingForEstimation
+                ? t('Waiting for estimation…')
+                : isGenerating
+                  ? t('Generating your unsigned transaction…')
+                  : t('Unable to generate')
+            }
+            disabled
+            multiline
+            numberOfLines={3}
+            inputStyle={spacings.pvMi}
+            nativeInputStyle={{ fontFamily: GEIST_MONO_FONT_FAMILIES.REGULAR, fontSize: 12 }}
+          />
+        </View>
+        {hasGenerationTimedOut && !unsignedTransaction ? (
+          <Button
+            testID="retry-unsigned-transaction-button"
+            type="secondary"
+            size="small"
+            hasBottomSpacing={false}
+            onPress={handleRetry}
+            text={t('Retry')}
+          />
+        ) : (
+          <Button
+            testID="copy-unsigned-transaction-button"
+            type="secondary"
+            size="small"
+            hasBottomSpacing={false}
+            disabled={!unsignedTransaction}
+            childrenPosition="left"
+            onPress={handleCopy}
+            text={t('Copy')}
+          >
+            <CopyIcon
+              strokeWidth={1.5}
+              width={20}
+              height={20}
+              color={theme.secondaryText}
+              style={spacings.mrTy}
+            />
+          </Button>
+        )}
+      </View>
+    </View>
+  )
+}
+
+export default memo(CopyUnsignedTransaction)

--- a/src/common/modules/sign-account-op/components/CopyUnsignedTransaction/index.ts
+++ b/src/common/modules/sign-account-op/components/CopyUnsignedTransaction/index.ts
@@ -1,0 +1,3 @@
+import CopyUnsignedTransaction from './CopyUnsignedTransaction'
+
+export default CopyUnsignedTransaction

--- a/src/common/modules/sign-account-op/components/OneClick/Estimation/Estimation.tsx
+++ b/src/common/modules/sign-account-op/components/OneClick/Estimation/Estimation.tsx
@@ -21,6 +21,7 @@ import useSign from '@common/hooks/useSign'
 import Estimation from '@common/modules/sign-account-op/components/Estimation'
 import BundlerWarning from '@common/modules/sign-account-op/components/Estimation/components/bundlerWarning'
 import SafetyChecksBanner from '@common/modules/sign-account-op/components/SafetyChecksBanner'
+import CopyUnsignedTransaction from '@common/modules/sign-account-op/components/CopyUnsignedTransaction'
 import { ModalsProps } from '@common/modules/sign-account-op/types/modals'
 import KeySelect from '@common/modules/sign-message/components/KeySelect'
 import spacings from '@common/styles/spacings'
@@ -38,6 +39,7 @@ export type OneClickEstimationProps = {
   serviceFee?: SwapAndBridgeRoute['serviceFee']
   shouldShowTxnDetails?: boolean
   Modals: React.ComponentType<ModalsProps>
+  onGenerateUnsignedTransaction?: () => void
 }
 
 const { isRequestWindow, isTab } = getUiType()
@@ -53,7 +55,8 @@ const OneClickEstimation = ({
   updateType,
   serviceFee,
   shouldShowTxnDetails = false,
-  Modals
+  Modals,
+  onGenerateUnsignedTransaction
 }: OneClickEstimationProps) => {
   const { t } = useTranslation()
   const hasFreshActionPressRef = useRef(false)
@@ -138,8 +141,8 @@ const OneClickEstimation = ({
         style={spacings.pb}
         closeBottomSheet={isWeb ? undefined : closeEstimationModal}
         autoOpen={hasProceeded || (isRequestWindow && !!signAccountOpController)}
-        isScrollEnabled={isMobile || shouldShowTxnDetails}
-        reserveScrollPadding={shouldShowTxnDetails}
+        isScrollEnabled={isMobile || shouldShowTxnDetails || !!onGenerateUnsignedTransaction}
+        reserveScrollPadding={shouldShowTxnDetails || !!onGenerateUnsignedTransaction}
         shouldBeClosableOnDrag={isMobile}
       >
         {!!banners && !!banners.length && (
@@ -195,6 +198,12 @@ const OneClickEstimation = ({
               <NoKeysToSignAlert
                 style={spacings.mt}
                 chainId={signAccountOpController?.accountOp?.chainId}
+              />
+            )}
+            {!!onGenerateUnsignedTransaction && (
+              <CopyUnsignedTransaction
+                signAccountOpState={signAccountOpController}
+                onGenerate={onGenerateUnsignedTransaction}
               />
             )}
             {!isViewOnly && signingErrors && signingErrors[0] && (

--- a/src/mobile/modules/sign-account-op/screens/SignAccountOpScreen/SignAccountOpScreen.tsx
+++ b/src/mobile/modules/sign-account-op/screens/SignAccountOpScreen/SignAccountOpScreen.tsx
@@ -19,6 +19,7 @@ import ErrorInformation from '@common/modules/sign-account-op/components/ErrorIn
 import Estimation from '@common/modules/sign-account-op/components/Estimation'
 import Footer from '@common/modules/sign-account-op/components/Footer'
 import PendingTransactions from '@common/modules/sign-account-op/components/PendingTransactions'
+import CopyUnsignedTransaction from '@common/modules/sign-account-op/components/CopyUnsignedTransaction'
 import SafeEip712Data from '@common/modules/sign-account-op/components/SafeEip712Data'
 import SafeOwners from '@common/modules/sign-account-op/components/SafeOwners'
 import SafetyChecksOverlay from '@common/modules/sign-account-op/components/SafetyChecksOverlay'
@@ -372,6 +373,18 @@ const SignAccountOpScreen = () => {
               chainId={signAccountOpState?.accountOp?.chainId}
             />
           )}
+          <CopyUnsignedTransaction
+            signAccountOpState={signAccountOpState}
+            onGenerate={() => {
+              signAccountOpDispatch({
+                type: 'method',
+                params: {
+                  method: 'generateUnsignedTransaction',
+                  args: []
+                }
+              })
+            }}
+          />
         </ScrollView>
       </MobileLayoutContainer>
     </View>

--- a/src/mobile/modules/swap-and-bridge/screens/SwapAndBridgeScreen/SwapAndBridgeScreen.tsx
+++ b/src/mobile/modules/swap-and-bridge/screens/SwapAndBridgeScreen/SwapAndBridgeScreen.tsx
@@ -269,6 +269,15 @@ const SwapAndBridgeScreen = () => {
           handleUpdateStatus={handleUpdateStatus}
           hasProceeded={hasProceeded}
           signAccountOpController={signAccountOpController}
+          onGenerateUnsignedTransaction={() => {
+            swapAndBridgeDispatch({
+              type: 'method',
+              params: {
+                method: 'callSignAccountOpMethod',
+                args: ['generateUnsignedTransaction', []]
+              }
+            })
+          }}
           serviceFee={quote?.selectedRoute?.serviceFee}
           Modals={Modals}
         />

--- a/src/mobile/modules/transfer/screens/TransferScreen/TransferScreen.tsx
+++ b/src/mobile/modules/transfer/screens/TransferScreen/TransferScreen.tsx
@@ -242,6 +242,15 @@ const TransferScreen = ({ isTopUpScreen }: { isTopUpScreen?: boolean }) => {
           handleUpdateStatus={handleUpdateStatus}
           hasProceeded={hasProceeded}
           signAccountOpController={signAccountOpController}
+          onGenerateUnsignedTransaction={() => {
+            transferDispatch({
+              type: 'method',
+              params: {
+                method: 'callSignAccountOpMethod',
+                args: ['generateUnsignedTransaction', []]
+              }
+            })
+          }}
           Modals={Modals}
         />
       </MobileLayoutWrapperMainContent>

--- a/src/web/modules/sign-account-op/screens/SignAccountOpScreen/SignAccountOpScreen.tsx
+++ b/src/web/modules/sign-account-op/screens/SignAccountOpScreen/SignAccountOpScreen.tsx
@@ -17,6 +17,7 @@ import ErrorInformation from '@common/modules/sign-account-op/components/ErrorIn
 import Estimation from '@common/modules/sign-account-op/components/Estimation'
 import Footer from '@common/modules/sign-account-op/components/Footer'
 import PendingTransactions from '@common/modules/sign-account-op/components/PendingTransactions'
+import CopyUnsignedTransaction from '@common/modules/sign-account-op/components/CopyUnsignedTransaction'
 import SafeEip712Data from '@common/modules/sign-account-op/components/SafeEip712Data'
 import SafeOwners from '@common/modules/sign-account-op/components/SafeOwners'
 import SafetyChecksOverlay from '@common/modules/sign-account-op/components/SafetyChecksOverlay'
@@ -379,6 +380,18 @@ const SignAccountOpScreen = () => {
                 chainId={signAccountOpState?.accountOp?.chainId}
               />
             )}
+            <CopyUnsignedTransaction
+              signAccountOpState={signAccountOpState}
+              onGenerate={() => {
+                signAccountOpDispatch({
+                  type: 'method',
+                  params: {
+                    method: 'generateUnsignedTransaction',
+                    args: []
+                  }
+                })
+              }}
+            />
           </ScrollView>
         </TabLayoutWrapperMainContent>
       </TabLayoutContainer>

--- a/src/web/modules/swap-and-bridge/screens/SwapAndBridgeScreen/SwapAndBridgeScreen.tsx
+++ b/src/web/modules/swap-and-bridge/screens/SwapAndBridgeScreen/SwapAndBridgeScreen.tsx
@@ -280,6 +280,15 @@ const SwapAndBridgeScreen = () => {
           handleUpdateStatus={handleUpdateStatus}
           hasProceeded={hasProceeded}
           signAccountOpController={signAccountOpController}
+          onGenerateUnsignedTransaction={() => {
+            swapAndBridgeDispatch({
+              type: 'method',
+              params: {
+                method: 'callSignAccountOpMethod',
+                args: ['generateUnsignedTransaction', []]
+              }
+            })
+          }}
           serviceFee={quote?.selectedRoute?.serviceFee}
           shouldShowTxnDetails
           Modals={Modals}

--- a/src/web/modules/transfer/screens/TransferScreen/TransferScreen.tsx
+++ b/src/web/modules/transfer/screens/TransferScreen/TransferScreen.tsx
@@ -723,6 +723,15 @@ const TransferScreen = ({ isTopUpScreen }: { isTopUpScreen?: boolean }) => {
           handleUpdateStatus={handleUpdateStatus}
           hasProceeded={hasProceeded}
           signAccountOpController={signAccountOpController}
+          onGenerateUnsignedTransaction={() => {
+            transferDispatch({
+              type: 'method',
+              params: {
+                method: 'callSignAccountOpMethod',
+                args: ['generateUnsignedTransaction', []]
+              }
+            })
+          }}
           Modals={Modals}
         />
       </Suspense>


### PR DESCRIPTION
Lets view-only Regular (EOA) accounts generate a copyable unsigned raw transaction (RLP pre-image) on the review screen, so it can be signed and broadcast with a wallet holding the private key.

- new CopyUnsignedTransaction box (explanation + read-only raw-tx field + copy button) rendered below the "no keys" alert
- wired into transfer, top-up, swap-and-bridge and dApp request review surfaces (web + mobile)
- view-only EOA gating; auto-generates once fee estimation completes; retry on failure
- enables the estimation modal scroll so the back button stays reachable

Depends on ambire-common#2589 (submodule pointer bumped to that branch head).