### PR TITLE
fix(inpage): surface RPC forwarding errors via console.debug in prod

### DIFF
--- a/src/mobile/modules/inpage/ambire-inpage.ts
+++ b/src/mobile/modules/inpage/ambire-inpage.ts
@@ -32,6 +32,17 @@ let forwardRpcRequestId = 0
 const foundDappRpcUrls: string[] = []
 let isDapp = false
 
+
+function logRpcForwardingError(error: unknown) {
+  if (isProd) {
+    // debug is off by default in browsers; keeps page console clean while still diagnosable
+    console.debug('[Ambire] RPC forwarding logic:', error)
+  } else {
+    console.error('RPC forwarding logic:', error)
+  }
+}
+
+
 ;(function () {
   // No frame check for mobile
 
@@ -57,11 +68,7 @@ let isDapp = false
         try {
           reqClone = (resource as Request).clone()
         } catch (error) {
-          if (isProd) {
-            // intentionally swallow internal ambire-inpage errors to avoid polluting the page console
-          } else {
-            console.error('RPC forwarding logic:', error)
-          }
+          logRpcForwardingError(error)
         }
 
         if (reqClone) {
@@ -78,11 +85,7 @@ let isDapp = false
               fetchURL = reqClone.url
               fetchBody = body
             } catch (error) {
-              if (isProd) {
-                // intentionally swallow internal ambire-inpage errors to avoid polluting the page console
-              } else {
-                console.error('RPC forwarding logic:', error)
-              }
+              logRpcForwardingError(error)
             }
           }
         }
@@ -97,11 +100,7 @@ let isDapp = false
               if (!foundDappRpcUrls.includes(fetchURL)) foundDappRpcUrls.push(fetchURL) // store potential RPC URL
             }
           } catch (error) {
-            if (isProd) {
-              // intentionally swallow internal ambire-inpage errors to avoid polluting the page console
-            } else {
-              console.error('RPC forwarding logic:', error)
-            }
+            logRpcForwardingError(error)
           }
         } else {
           try {
@@ -117,11 +116,7 @@ let isDapp = false
         }
       }
     })().catch((err) => {
-      if (isProd) {
-        // intentionally swallow internal ambire-inpage errors to avoid polluting the page console
-      } else {
-        console.error('RPC forwarding logic:', err)
-      }
+      logRpcForwardingError(err)
     })
 
     return originalFetch(...args)

--- a/src/web/modules/inpage/ambire-inpage.ts
+++ b/src/web/modules/inpage/ambire-inpage.ts
@@ -35,6 +35,17 @@ let forwardRpcRequestId = 0
 const foundDappRpcUrls: string[] = []
 let isDapp = false
 
+
+function logRpcForwardingError(error: unknown) {
+  if (isProd) {
+    // debug is off by default in browsers; keeps page console clean while still diagnosable
+    console.debug('[Ambire] RPC forwarding logic:', error)
+  } else {
+    console.error('RPC forwarding logic:', error)
+  }
+}
+
+
 ;(function () {
   if (isCrossOriginFrame() || isTooDeepFrameInTheFrameHierarchy()) return
 
@@ -60,11 +71,7 @@ let isDapp = false
         try {
           reqClone = (resource as Request).clone()
         } catch (error) {
-          if (isProd) {
-            // intentionally swallow internal ambire-inpage errors to avoid polluting the page console
-          } else {
-            console.error('RPC forwarding logic:', error)
-          }
+          logRpcForwardingError(error)
         }
 
         if (reqClone) {
@@ -81,11 +88,7 @@ let isDapp = false
               fetchURL = reqClone.url
               fetchBody = body
             } catch (error) {
-              if (isProd) {
-                // intentionally swallow internal ambire-inpage errors to avoid polluting the page console
-              } else {
-                console.error('RPC forwarding logic:', error)
-              }
+              logRpcForwardingError(error)
             }
           }
         }
@@ -100,11 +103,7 @@ let isDapp = false
               if (!foundDappRpcUrls.includes(fetchURL)) foundDappRpcUrls.push(fetchURL) // store potential RPC URL
             }
           } catch (error) {
-            if (isProd) {
-              // intentionally swallow internal ambire-inpage errors to avoid polluting the page console
-            } else {
-              console.error('RPC forwarding logic:', error)
-            }
+            logRpcForwardingError(error)
           }
         } else {
           try {
@@ -120,11 +119,7 @@ let isDapp = false
         }
       }
     })().catch((err) => {
-      if (isProd) {
-        // intentionally swallow internal ambire-inpage errors to avoid polluting the page console
-      } else {
-        console.error('RPC forwarding logic:', err)
-      }
+      logRpcForwardingError(err)
     })
 
     return originalFetch(...args)


### PR DESCRIPTION
## Summary

Fixes #23.

Ambire's inpage script wraps `window.fetch` to discover dapp RPC URLs. When that wrapper hits clone / JSON / body-stream failures (common with ERC-4337 + Alto, Vite proxies, and `new Request(...)` bodies), production builds currently swallow the error in empty `catch` blocks. The page fetch still runs, but there is no Ambire signal in the console, so integrators burn time debugging their own stack.

This change keeps the fire-and-forget design (the page `fetch` is never failed by Ambire) and replaces the empty prod swallows with `console.debug('[Ambire] RPC forwarding logic:', ...)`. `console.debug` stays off in default DevTools settings, so we are not dumping noise into every dapp console, but Verbose / debug logging makes interference diagnosable. Non-prod still uses `console.error` as before.

Same helper is applied in both:

- `src/web/modules/inpage/ambire-inpage.ts`
- `src/mobile/modules/inpage/ambire-inpage.ts`

## Test plan

- [ ] Load a dapp with Ambire enabled and confirm normal RPC / wallet flows still work
- [ ] Force a Request-body / clone failure path (e.g. Alto + Vite proxy as in #23) with DevTools Verbose logging and confirm `[Ambire] RPC forwarding logic:` appears instead of silence
- [ ] Confirm the underlying page `fetch` still resolves (Ambire must not reject it)